### PR TITLE
feat: SQLite job persistence and history UI

### DIFF
--- a/src/chalna/db.py
+++ b/src/chalna/db.py
@@ -1,0 +1,222 @@
+"""
+SQLite job persistence store for Chalna.
+
+DB file lives at RESULTS_DIR/chalna.db alongside result files.
+The DB is the source of truth for job history; results/ files may be
+cleaned up independently.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# Will be set by init_db()
+_db_path: Optional[Path] = None
+
+
+def _connect() -> sqlite3.Connection:
+    assert _db_path is not None, "Call init_db() first"
+    conn = sqlite3.connect(str(_db_path), timeout=10)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    return conn
+
+
+def init_db(results_dir: Path) -> None:
+    """Create tables if needed. Must be called once at startup."""
+    global _db_path
+    _db_path = results_dir / "chalna.db"
+
+    with _connect() as conn:
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS jobs (
+                job_id          TEXT PRIMARY KEY,
+                status          TEXT NOT NULL,
+                created_at      TEXT NOT NULL,
+                started_at      TEXT,
+                completed_at    TEXT,
+                audio_duration  REAL,
+                error           TEXT,
+                refined         INTEGER,
+                results_dir     TEXT,
+                has_result_files INTEGER DEFAULT 0
+            )
+        """)
+        conn.execute("""
+            CREATE INDEX IF NOT EXISTS idx_jobs_created
+            ON jobs (created_at DESC)
+        """)
+
+
+def save_job(job: Dict[str, Any]) -> None:
+    """INSERT OR REPLACE a job record."""
+    with _connect() as conn:
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO jobs
+                (job_id, status, created_at, started_at, completed_at,
+                 audio_duration, error, refined, results_dir, has_result_files)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                job["job_id"],
+                job["status"],
+                job["created_at"],
+                job.get("started_at"),
+                job.get("completed_at"),
+                job.get("audio_duration"),
+                job.get("error"),
+                _bool_to_int(job.get("refined")),
+                job.get("results_dir"),
+                1 if job.get("has_result_files") else 0,
+            ),
+        )
+
+
+def list_jobs(
+    status: Optional[str] = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> List[Dict[str, Any]]:
+    """List jobs ordered by created_at DESC."""
+    with _connect() as conn:
+        if status:
+            rows = conn.execute(
+                "SELECT * FROM jobs WHERE status = ? ORDER BY created_at DESC LIMIT ? OFFSET ?",
+                (status, limit, offset),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT * FROM jobs ORDER BY created_at DESC LIMIT ? OFFSET ?",
+                (limit, offset),
+            ).fetchall()
+    return [_row_to_dict(r) for r in rows]
+
+
+def get_job(job_id: str) -> Optional[Dict[str, Any]]:
+    """Get a single job by ID."""
+    with _connect() as conn:
+        row = conn.execute(
+            "SELECT * FROM jobs WHERE job_id = ?", (job_id,)
+        ).fetchone()
+    return _row_to_dict(row) if row else None
+
+
+def count_jobs(status: Optional[str] = None) -> int:
+    """Count total jobs, optionally filtered by status."""
+    with _connect() as conn:
+        if status:
+            row = conn.execute(
+                "SELECT COUNT(*) FROM jobs WHERE status = ?", (status,)
+            ).fetchone()
+        else:
+            row = conn.execute("SELECT COUNT(*) FROM jobs").fetchone()
+    return row[0]
+
+
+def migrate_from_results_dir(results_dir: Path) -> int:
+    """Scan existing results/ directories and insert missing jobs into DB.
+
+    Returns number of jobs migrated.
+    """
+    migrated = 0
+
+    for sub in sorted(results_dir.iterdir()):
+        if not sub.is_dir():
+            continue
+        # Skip non-job directories (like chalna.db file)
+        dir_name = sub.name
+        if len(dir_name) != 8:
+            continue
+
+        # Find JSON files (result or error)
+        json_files = list(sub.glob("*.json"))
+        if not json_files:
+            continue
+
+        # Pick the main JSON (prefer non-error, take first)
+        main_json = None
+        error_json = None
+        for jf in json_files:
+            if "_error" in jf.name:
+                error_json = jf
+            else:
+                main_json = jf
+
+        target = main_json or error_json
+        if not target:
+            continue
+
+        try:
+            data = json.loads(target.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+
+        job_id = data.get("job_id")
+        if not job_id:
+            continue
+
+        # Skip if already in DB
+        if get_job(job_id) is not None:
+            continue
+
+        # Extract metadata
+        status = data.get("status", "completed")
+        created_at = data.get("created_at", "")
+        completed_at = data.get("completed_at")
+        error = data.get("error")
+
+        # Audio duration from result metadata
+        audio_duration = None
+        result_meta = data.get("result", {})
+        if isinstance(result_meta, dict):
+            meta = result_meta.get("metadata", {})
+            if isinstance(meta, dict):
+                audio_duration = meta.get("duration")
+
+        # Refined flag
+        refined = None
+        if isinstance(result_meta, dict):
+            meta = result_meta.get("metadata", {})
+            if isinstance(meta, dict) and "refined" in meta:
+                refined = meta["refined"]
+
+        # Check for SRT files
+        has_srt = any(f.suffix == ".srt" for f in sub.iterdir())
+
+        save_job({
+            "job_id": job_id,
+            "status": status,
+            "created_at": created_at,
+            "started_at": None,
+            "completed_at": completed_at,
+            "audio_duration": audio_duration,
+            "error": error,
+            "refined": refined,
+            "results_dir": dir_name,
+            "has_result_files": has_srt,
+        })
+        migrated += 1
+
+    return migrated
+
+
+# --- Internal helpers ---
+
+def _bool_to_int(val: Optional[bool]) -> Optional[int]:
+    if val is None:
+        return None
+    return 1 if val else 0
+
+
+def _row_to_dict(row: sqlite3.Row) -> Dict[str, Any]:
+    d = dict(row)
+    # Convert refined back to bool
+    if d.get("refined") is not None:
+        d["refined"] = bool(d["refined"])
+    d["has_result_files"] = bool(d.get("has_result_files"))
+    return d

--- a/src/chalna/static/index.html
+++ b/src/chalna/static/index.html
@@ -295,6 +295,106 @@ details summary:hover { background: var(--accent-bright); }
 
 .error-box .error-title { font-weight: 600; margin-bottom: 4px; }
 .error-box .error-msg { font-size: 0.9rem; }
+
+/* --- History Panel --- */
+.history-panel {
+  max-width: 1200px;
+  margin: 0 auto 24px;
+  padding: 0 24px;
+}
+
+.history-panel .panel { padding: 16px 20px; }
+
+.history-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.history-header h2 { margin-bottom: 0; }
+
+.history-header .total-count {
+  font-size: 0.8rem;
+  color: var(--text-dim);
+}
+
+.history-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.history-table th {
+  text-align: left;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-dim);
+  font-weight: 500;
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+.history-table td {
+  padding: 8px 10px;
+  border-bottom: 1px solid rgba(42, 58, 94, 0.4);
+  vertical-align: middle;
+}
+
+.history-table tr { cursor: pointer; transition: background 0.15s; }
+.history-table tbody tr:hover { background: rgba(15, 52, 96, 0.3); }
+.history-table tr.selected { background: rgba(15, 52, 96, 0.5); }
+
+.status-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-right: 6px;
+  vertical-align: middle;
+}
+
+.status-dot.completed { background: var(--success); }
+.status-dot.failed { background: var(--error); }
+
+.badge-sm {
+  display: inline-block;
+  font-size: 0.7rem;
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-weight: 500;
+}
+
+.badge-sm.refined { background: var(--success); color: #fff; }
+.badge-sm.unrefined { background: var(--warning); color: #1a1a2e; }
+.badge-sm.no-files { background: rgba(255,255,255,0.1); color: var(--text-dim); }
+
+.history-empty {
+  text-align: center;
+  padding: 24px;
+  color: var(--text-dim);
+  font-size: 0.9rem;
+}
+
+.history-pager {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.history-pager button {
+  padding: 4px 14px;
+  background: var(--accent);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.history-pager button:disabled { opacity: 0.3; cursor: not-allowed; }
+.history-pager button:hover:not(:disabled) { background: var(--accent-bright); }
 </style>
 </head>
 <body>
@@ -365,6 +465,33 @@ details summary:hover { background: var(--accent-bright); }
         <div class="error-title" id="error-title">오류</div>
         <div class="error-msg" id="error-msg"></div>
       </div>
+    </div>
+  </div>
+</div>
+
+<!-- History Panel -->
+<div class="history-panel">
+  <div class="panel">
+    <div class="history-header">
+      <h2>히스토리</h2>
+      <span class="total-count" id="history-count"></span>
+    </div>
+    <table class="history-table" id="history-table">
+      <thead>
+        <tr>
+          <th>상태</th>
+          <th>일시</th>
+          <th>길이</th>
+          <th>교정</th>
+          <th>파일</th>
+        </tr>
+      </thead>
+      <tbody id="history-body"></tbody>
+    </table>
+    <div class="history-empty" id="history-empty" style="display:none">기록이 없습니다.</div>
+    <div class="history-pager" id="history-pager" style="display:none">
+      <button id="history-prev" disabled>이전</button>
+      <button id="history-next" disabled>다음</button>
     </div>
   </div>
 </div>
@@ -591,6 +718,7 @@ details summary:hover { background: var(--accent-bright); }
 
     if (job.status === 'completed') {
       showResult(job);
+      loadHistory();
       return;
     }
 
@@ -599,6 +727,7 @@ details summary:hover { background: var(--accent-bright); }
       const title = code ? `오류 [${code}]` : '오류';
       showError(title, job.error || '알 수 없는 오류');
       btnSubmit.disabled = false;
+      loadHistory();
       return;
     }
   }
@@ -627,8 +756,14 @@ details summary:hover { background: var(--accent-bright); }
     }
 
     // Duration
-    const elapsed = ((Date.now() - jobStartTime) / 1000);
-    resultDuration.textContent = `소요 시간: ${formatDuration(elapsed)}`;
+    if (jobStartTime) {
+      const elapsed = ((Date.now() - jobStartTime) / 1000);
+      resultDuration.textContent = `소요 시간: ${formatDuration(elapsed)}`;
+    } else if (job.audio_duration) {
+      resultDuration.textContent = `오디오 길이: ${formatDuration(job.audio_duration)}`;
+    } else {
+      resultDuration.textContent = '';
+    }
 
     // Download
     btnDownload.onclick = () => downloadSrt(job.result || '', 'output.srt');
@@ -702,6 +837,131 @@ details summary:hover { background: var(--accent-bright); }
     div.textContent = str;
     return div.innerHTML;
   }
+
+  // ==========================================================================
+  // Job History
+  // ==========================================================================
+  const historyBody = document.getElementById('history-body');
+  const historyCount = document.getElementById('history-count');
+  const historyEmpty = document.getElementById('history-empty');
+  const historyPager = document.getElementById('history-pager');
+  const historyPrev = document.getElementById('history-prev');
+  const historyNext = document.getElementById('history-next');
+
+  const PAGE_SIZE = 20;
+  let historyOffset = 0;
+  let historyTotal = 0;
+
+  async function loadHistory() {
+    try {
+      const res = await fetch(`/jobs?limit=${PAGE_SIZE}&offset=${historyOffset}`);
+      if (!res.ok) return;
+      const data = await res.json();
+      historyTotal = data.total;
+      renderHistory(data.jobs);
+    } catch (err) {
+      console.error('History load error:', err);
+    }
+  }
+
+  function renderHistory(jobs) {
+    historyCount.textContent = `${historyTotal}건`;
+
+    if (jobs.length === 0 && historyOffset === 0) {
+      historyBody.innerHTML = '';
+      historyEmpty.style.display = '';
+      historyPager.style.display = 'none';
+      return;
+    }
+
+    historyEmpty.style.display = 'none';
+    historyBody.innerHTML = '';
+
+    for (const job of jobs) {
+      const tr = document.createElement('tr');
+      tr.dataset.jobId = job.job_id;
+
+      // Status
+      const statusDot = `<span class="status-dot ${job.status}"></span>${job.status === 'completed' ? '완료' : '실패'}`;
+
+      // Date
+      const dt = job.created_at ? new Date(job.created_at + 'Z') : null;
+      const dateStr = dt ? dt.toLocaleString('ko-KR', { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' }) : '-';
+
+      // Duration
+      let durStr = '-';
+      if (job.audio_duration) {
+        durStr = formatDuration(job.audio_duration);
+      }
+
+      // Refined badge
+      let refinedHtml = '-';
+      if (job.refined === true) {
+        refinedHtml = '<span class="badge-sm refined">O</span>';
+      } else if (job.refined === false) {
+        refinedHtml = '<span class="badge-sm unrefined">X</span>';
+      }
+
+      // Files available
+      let filesHtml = job.has_result_files ? 'O' : '<span class="badge-sm no-files">-</span>';
+
+      tr.innerHTML = `<td>${statusDot}</td><td>${dateStr}</td><td>${durStr}</td><td>${refinedHtml}</td><td>${filesHtml}</td>`;
+
+      tr.addEventListener('click', () => viewHistoryJob(job.job_id));
+      historyBody.appendChild(tr);
+    }
+
+    // Pager
+    if (historyTotal > PAGE_SIZE) {
+      historyPager.style.display = '';
+      historyPrev.disabled = historyOffset === 0;
+      historyNext.disabled = historyOffset + PAGE_SIZE >= historyTotal;
+    } else {
+      historyPager.style.display = 'none';
+    }
+  }
+
+  async function viewHistoryJob(jobId) {
+    try {
+      const res = await fetch(`/jobs/${jobId}`);
+      if (!res.ok) return;
+      const job = await res.json();
+
+      // Highlight selected row
+      historyBody.querySelectorAll('tr').forEach(r => r.classList.remove('selected'));
+      const row = historyBody.querySelector(`tr[data-job-id="${jobId}"]`);
+      if (row) row.classList.add('selected');
+
+      if (job.status === 'completed' && job.result) {
+        jobStartTime = null;
+        showResult(job);
+      } else if (job.status === 'completed') {
+        showView('result');
+        srtOutput.value = '(결과 파일이 삭제되었습니다)';
+        resultBadge.innerHTML = '';
+        resultDuration.textContent = '';
+        intermediateSection.style.display = 'none';
+        btnDownload.onclick = null;
+      } else if (job.status === 'failed') {
+        showError('오류', job.error || '알 수 없는 오류');
+      }
+    } catch (err) {
+      console.error('View job error:', err);
+    }
+  }
+
+  historyPrev.addEventListener('click', () => {
+    historyOffset = Math.max(0, historyOffset - PAGE_SIZE);
+    loadHistory();
+  });
+
+  historyNext.addEventListener('click', () => {
+    historyOffset += PAGE_SIZE;
+    loadHistory();
+  });
+
+  // Load history on page load
+  loadHistory();
 })();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- SQLite DB(`results/chalna.db`)로 job 메타데이터 영속화 — 서버 재시작해도 히스토리 유지
- `GET /jobs` 엔드포인트 추가 (status 필터, 페이지네이션)
- `GET /jobs/{id}` DB fallback — 인메모리에 없으면 DB 조회 후 디스크에서 SRT 로드
- Web UI에 히스토리 패널 추가 (클릭하면 결과 조회, 페이지네이션)

Closes #1

## 변경 파일
- `src/chalna/db.py` (신규) — SQLite job store
- `src/chalna/server.py` — DB 초기화, migration, GET /jobs, DB fallback
- `src/chalna/static/index.html` — 히스토리 패널 UI

## Test plan
- [x] 서버 시작 → 기존 36개 job DB migration 확인
- [x] `GET /jobs` → 전체 목록 조회
- [x] `GET /jobs/{id}` → DB fallback + SRT 로드 확인
- [x] `GET /jobs/non-existent` → 404
- [x] 2차 startup → migration 0건 (idempotent)
- [ ] 새 transcription 후 DB 저장 확인
- [ ] Web UI 히스토리 패널 클릭 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)